### PR TITLE
[Challenge 2024 - HAFNIUM] EC1369 Use orElseGet instead of orElse

### DIFF
--- a/src/main/java/fr/greencodeinitiative/java/checks/UseOptionalOrElseGetVsOrElse.java
+++ b/src/main/java/fr/greencodeinitiative/java/checks/UseOptionalOrElseGetVsOrElse.java
@@ -1,0 +1,28 @@
+package fr.greencodeinitiative.java.checks;
+
+public class UseOptionalOrElseGetVsOrElse {
+    java.util.Optional<String> optional = java.util.Optional.of("test");
+
+    public void nonCompliantOrElse() {
+        String value = optional.orElse(getDefaultValue()); // Noncompliant {{Use optional orElseGet instead of orElse.}}
+    }
+
+    public void compliantOrElseGet() {
+        String value = optional.orElseGet(() -> getDefaultValue()); // Compliant
+    }
+
+    public void compliantOrElse() {
+        String value = new RandomClass().orElse(getDefaultValue()); // Compliant
+    }
+
+    private String getDefaultValue() {
+        return "default";
+    }
+
+    private class RandomClass {
+
+        public String orElse(String value) {
+            return value;
+        }
+    }
+}


### PR DESCRIPTION
Parameter of orElse() is evaluated, even when having a non-empty Optional. orElseGet supplier method passed as an argument is only executed when an Optional value isn’t present :

https://github.com/green-code-initiative/ecoCode-challenge/issues/77